### PR TITLE
fix: set default values for indexer that permit forward progress on indexing without requiring 14 archive nodes

### DIFF
--- a/.env
+++ b/.env
@@ -39,8 +39,27 @@ SECRET_KEY_BASE=56NtB48ear7+wMSf0IQuWDAAazhpb31qyc7GiyspBP2vh7t5zlCsF5QDv76chXeN
 INDEXER_DISABLE_PENDING_TRANSACTIONS_FETCHER=true
 ETHEREUM_JSONRPC_VARIANT=geth
 ETHEREUM_JSONRPC_HTTP_URL=http://kava:8545
+# uncomment below to have blockscout index public testnet
+# ETHEREUM_JSONRPC_HTTP_URL=https://evm.data-testnet.kava.io
+# ETHEREUM_JSONRPC_WS_URL=wss://wevm.data-testnet.kava.io
+# uncomment below to have blockscout index mainnet
+# ETHEREUM_JSONRPC_HTTP_URL=https://evm.data.kava.io
+# ETHEREUM_JSONRPC_WS_URL=wss://wevm.data.kava.io
+
 NETWORK= "Kava Ethereum Co-Chain"
 LOGO="/images/kava-logo.png"
 LOGO_TEXT="Ethereum Co-Chain"
 COIN=KAVA
 BLOCKSCOUT_VERSION=v5.1.5-kava
+
+# settings used to control blockscout indexer behavior and request rates
+# https://docs.blockscout.com/for-developers/information-and-settings/env-variables#indexer-management
+INDEXER_CATCHUP_BLOCKS_BATCH_SIZE=1
+INDEXER_CATCHUP_BLOCKS_CONCURRENCY=1
+INDEXER_INTERNAL_TRANSACTIONS_CONCURRENCY=1
+INDEXER_BLOCK_REWARD_CONCURRENCY=1
+INDEXER_RECEIPTS_CONCURRENCY=1
+INDEXER_COIN_BALANCES_CONCURRENCY=1
+INDEXER_CATCHUP_BLOCK_INTERVAL=5s
+# The block number, where import of blocks by catchup fetcher begins from.
+FIRST_BLOCK=0

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -150,6 +150,63 @@ cd ../../
 make refresh
 ```
 
+#### Indexer status
+
+To see how far back the block explorer has indexed blocks, connect to the database and query to see what is the earliest block it has indexed, if these values change that means earlier and earlier blocks are being indexed (`refetch_needed` indicates whether the indexing was successful)
+
+```bash
+make debug-database
+blockscout_testing=# select number, inserted_at, updated_at, refetch_needed from blocks order by number asc limit 5;
+ number  |        inserted_at         |         updated_at         | refetch_needed
+---------+----------------------------+----------------------------+----------------
+ 5762464 | 2023-06-16 00:27:58.151073 | 2023-06-16 00:27:58.151073 | f
+ 5762465 | 2023-06-16 00:27:58.032291 | 2023-06-16 00:27:58.032291 | f
+ 5762466 | 2023-06-16 00:27:57.890547 | 2023-06-16 00:27:57.890547 | f
+ 5762467 | 2023-06-16 00:27:57.774853 | 2023-06-16 00:27:57.774853 | f
+ 5762468 | 2023-06-16 00:27:57.658246 | 2023-06-16 00:27:57.658246 | f
+(5 rows)
+
+blockscout_testing=# select number, inserted_at, updated_at, refetch_needed from blocks order by number asc limit 5;
+ number  |        inserted_at         |         updated_at         | refetch_needed
+---------+----------------------------+----------------------------+----------------
+ 5762461 | 2023-06-16 00:27:58.521786 | 2023-06-16 00:27:58.521786 | f
+ 5762462 | 2023-06-16 00:27:58.409383 | 2023-06-16 00:27:58.409383 | f
+ 5762463 | 2023-06-16 00:27:58.272033 | 2023-06-16 00:27:58.272033 | f
+ 5762464 | 2023-06-16 00:27:58.151073 | 2023-06-16 00:27:58.151073 | f
+ 5762465 | 2023-06-16 00:27:58.032291 | 2023-06-16 00:27:58.032291 | f
+(5 rows)
+
+blockscout_testing=# select number, inserted_at, updated_at, refetch_needed from blocks order by number asc limit 5;
+ number  |        inserted_at         |         updated_at         | refetch_needed
+---------+----------------------------+----------------------------+----------------
+ 5762458 | 2023-06-16 00:27:59.161544 | 2023-06-16 00:27:59.161544 | f
+ 5762459 | 2023-06-16 00:27:59.023982 | 2023-06-16 00:27:59.023982 | f
+ 5762460 | 2023-06-16 00:27:58.752723 | 2023-06-16 00:27:58.752723 | f
+ 5762461 | 2023-06-16 00:27:58.521786 | 2023-06-16 00:27:58.521786 | f
+ 5762462 | 2023-06-16 00:27:58.409383 | 2023-06-16 00:27:58.409383 | f
+(5 rows)
+```
+
+#### Running local explorer against production network(s)
+
+Update values in the [local environment file](.env) to point to the archive / pruning endpoint of the network you want your local instance of Blockscout to index
+
+```bash
+# ETHEREUM_JSONRPC_HTTP_URL=http://kava:8545
+# uncomment below to have blockscout index public testnet
+ETHEREUM_JSONRPC_HTTP_URL=https://evm.data-testnet.kava.io
+ETHEREUM_JSONRPC_WS_URL=wss://wevm.data-testnet.kava.io
+# uncomment below to have blockscout index mainnet
+# ETHEREUM_JSONRPC_HTTP_URL=https://evm.data.kava.io
+# ETHEREUM_JSONRPC_WS_URL=wss://wevm.data.kava.io
+```
+
+```bash
+# wipe all state and restart containers with updated environment variables
+make reset
+```
+
+Open the [Blockscout UI](http://localhost:4000) to inspect progress
 
 ### Postgres
 


### PR DESCRIPTION
- document how to check the status of the blockscout indexer process
- document how to run explorer locally to index a production network (e.g. mainnet or public testnet)

initial testing shows that a single blockscout process running on my computer with the settings in `.env` are able to stay at tip AND index older blocks at a reasonable clip without overwhelming either a single node locally or a cluster of remote nodes